### PR TITLE
Fix: RDS GP3 storage minimum requirement

### DIFF
--- a/infrastructure/lib/database-stack.ts
+++ b/infrastructure/lib/database-stack.ts
@@ -95,7 +95,7 @@ export class DatabaseStack extends cdk.Stack {
       securityGroups: [props.securityGroup],
       subnetGroup: subnetGroup,
       parameterGroup: parameterGroup,
-      allocatedStorage: 10, // Reduced from 20GB to minimize costs
+      allocatedStorage: 20, // GP3 minimum storage requirement for PostgreSQL
       storageType: rds.StorageType.GP3, // GP3 is more cost-effective than GP2
       backupRetention: cdk.Duration.days(1),
       deleteAutomatedBackups: true,


### PR DESCRIPTION
## Summary

Fixes the database stack deployment failure caused by GP3 storage minimum size requirements for PostgreSQL.

## Problem

The database stack failed to deploy with error:
```
Invalid storage size for engine name postgres and storage type gp3: 10
```

GP3 storage type has a minimum size requirement of 20GB for PostgreSQL, but our cost optimization had reduced it to 10GB.

## Solution

- Increase `allocatedStorage` from 10GB back to 20GB
- Maintain GP3 storage type for better cost efficiency vs GP2
- Update comment to reflect GP3 minimum requirement

## Changes Made

**Database Stack (`database-stack.ts`):**
```typescript
// Before
allocatedStorage: 10, // Reduced from 20GB to minimize costs
storageType: rds.StorageType.GP3, // GP3 is more cost-effective than GP2

// After  
allocatedStorage: 20, // GP3 minimum storage requirement for PostgreSQL
storageType: rds.StorageType.GP3, // GP3 is more cost-effective than GP2
```

## Cost Impact

- **Storage cost remains the same** as original (20GB)
- **Still saves money** by using GP3 instead of GP2 storage type
- **No impact on other cost optimizations** (NAT Gateway, Fargate, CloudWatch, etc.)

## Expected Outcome

✅ Database stack deploys successfully  
✅ Maintains GP3 cost benefits vs GP2  
✅ Meets AWS minimum storage requirements  
✅ No impact on application functionality  

## Test Plan

- [ ] Deploy database stack without storage validation errors
- [ ] Verify application connectivity to database
- [ ] Confirm storage type is GP3 in AWS console
- [ ] Monitor storage costs remain optimized

🤖 Generated with [Claude Code](https://claude.ai/code)