### PR TITLE
Fix: ECS migration task subnet configuration

### DIFF
--- a/infrastructure/lib/compute-stack.ts
+++ b/infrastructure/lib/compute-stack.ts
@@ -283,10 +283,13 @@ export class ComputeStack extends cdk.Stack {
     });
 
     // Output network configuration for migration tasks
+    // Use the same subnet selection as the ECS service
+    const migrationSubnets = props.vpc.selectSubnets({
+      subnetGroupName: "private",
+    });
+
     new cdk.CfnOutput(this, "ECSSubnets", {
-      value: props.vpc.privateSubnets
-        .map((subnet) => subnet.subnetId)
-        .join(","),
+      value: migrationSubnets.subnetIds.join(","),
       description: "Private subnet IDs for ECS tasks",
     });
 


### PR DESCRIPTION
## Summary

Fixes the database migration failure in GitHub Actions caused by empty subnet configuration after the cost optimization changes.

## Problem

The backend deployment failed on the "Run DB migrations" step with error:
```
An error occurred (InvalidParameterException) when calling the RunTask operation: subnets can not be empty.
```

This happened because our cost optimization changed the VPC subnet configuration, and the CDK output for `ECSSubnets` started returning an empty value.

## Root Cause

In the compute stack, the subnet output was using:
```typescript
props.vpc.privateSubnets.map((subnet) => subnet.subnetId)
```

After changing the subnet configuration to use `PRIVATE_ISOLATED` instead of `PRIVATE_WITH_EGRESS`, CDK's `privateSubnets` property became empty, causing the GitHub Actions workflow to receive no subnet IDs.

## Solution

Changed the subnet selection to explicitly target the same subnets that the ECS service uses:

```typescript
// Before
value: props.vpc.privateSubnets
  .map((subnet) => subnet.subnetId)
  .join(","),

// After
const migrationSubnets = props.vpc.selectSubnets({
  subnetGroupName: "private",
});

value: migrationSubnets.subnetIds.join(","),
```

## Changes Made

**Compute Stack (`compute-stack.ts`):**
- Use `vpc.selectSubnets()` with `subnetGroupName: "private"` 
- Ensures migration tasks use the same subnets as the ECS service
- Provides consistent subnet selection regardless of subnet type changes

## Expected Outcome

✅ GitHub Actions can successfully retrieve subnet IDs from CDK outputs  
✅ ECS migration tasks can run in the correct private subnets  
✅ Database migrations complete successfully during deployment  
✅ No changes needed to existing GitHub Actions workflow  

## Test Plan

- [ ] Deploy compute stack and verify `ECSSubnets` output contains valid subnet IDs
- [ ] Run backend deployment to test migration task execution
- [ ] Confirm migration task runs in private subnets with VPC endpoint connectivity
- [ ] Verify application deployment completes end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)