### PR TITLE
Fix prod login

### DIFF
--- a/taps-backend/taps_backend/settings.py
+++ b/taps-backend/taps_backend/settings.py
@@ -166,4 +166,6 @@ SOCIALACCOUNT_EMAIL_REQUIRED = True
 # Session settings
 SESSION_COOKIE_AGE = 604800  # 1 week (reduced from 2 weeks for security)
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SAMESITE = "Lax"  # Lax allows cross-origin cookies (required for cross-domain auth)
+SESSION_COOKIE_SAMESITE = (
+    "Lax"  # Lax allows cross-origin cookies (required for cross-domain auth)
+)


### PR DESCRIPTION
Changes:
- Change same site cookie type to Lax to support cross-domain cookies (for Vercel URL vs. back-end URL)
    - Recommended by Claude

Noticed this when testing in prod